### PR TITLE
fix/release-bugs

### DIFF
--- a/apps/miso/cmd/main.go
+++ b/apps/miso/cmd/main.go
@@ -84,16 +84,7 @@ func main() {
 			}
 			return
 		case "version", "v":
-			// load config if available
-			var projectRoot string
-			var cfg config.Config
-			if root, err := cli.FindProjectRoot(originalWorkDir); err == nil {
-				projectRoot = root
-				if loadedCfg, err := cli.LoadConfig(projectRoot); err == nil {
-					cfg = loadedCfg
-				}
-			}
-			if err := commands.RunVersion(projectRoot, cfg); err != nil {
+			if err := commands.RunVersion(); err != nil {
 				cli.Fail(logger, err, false)
 			}
 			return

--- a/apps/miso/internal/cli/commands/upgrade.go
+++ b/apps/miso/internal/cli/commands/upgrade.go
@@ -16,8 +16,7 @@ import (
 
 const githubLatestURL = "https://api.github.com/repos/ekkolyth/miso/releases/latest"
 
-// HTTPClient is an interface for making HTTP GET requests.
-// It exists so tests can inject a mock without spawning a real HTTP server.
+// for test injection without a real HTTP server
 type HTTPClient interface {
 	Get(url string) (*http.Response, error)
 }

--- a/apps/miso/internal/cli/commands/version.go
+++ b/apps/miso/internal/cli/commands/version.go
@@ -1,87 +1,15 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
-
-	"github.com/ekkolyth/miso/internal/config"
-	"github.com/ekkolyth/miso/internal/manager"
 )
 
-// return miso version from package.json
-func GetMisoVersion() (string, error) {
-	type packageInfo struct {
-		Version string `json:"version"`
-	}
-
-	// Walk up from the binary's own location to find miso's package.json.
-	// We never look in CWD node_modules — miso version must always reflect
-	// the version of the running binary, not whatever happens to be installed
-	// as a local dependency in the current project.
-	var packageJSONPaths []string
-
-	var startDir string
-	if exe, err := os.Executable(); err == nil {
-		startDir, _ = filepath.Abs(filepath.Dir(exe))
-	} else {
-		return "", fmt.Errorf("could not determine binary location")
-	}
-	for i := 0; i < 10; i++ {
-		pkgPath := filepath.Join(startDir, "package.json")
-		packageJSONPaths = append(packageJSONPaths, pkgPath)
-		parent := filepath.Dir(startDir)
-		if parent == startDir {
-			break
-		}
-		startDir = parent
-	}
-
-	// try each path in order
-	for _, path := range packageJSONPaths {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-
-		var info packageInfo
-		if err := json.Unmarshal(data, &info); err != nil {
-			continue
-		}
-
-		if info.Version != "" {
-			return info.Version, nil
-		}
-	}
-
-	return "", fmt.Errorf("could not find package.json with version")
-}
+// Version is set at build time via -ldflags "-X github.com/ekkolyth/miso/internal/cli/commands.Version=x.y.z"
+var Version = "unknown"
 
 // miso version
-func RunVersion(root string, cfg config.Config) error {
-	misoVersion, err := GetMisoVersion()
-	if err != nil {
-		// If we can't get version, show unknown but don't fail
-		misoVersion = "unknown"
-	}
-	fmt.Fprintf(os.Stdout, "miso %s\n", misoVersion)
-
-	// get manager version if available
-	managerName, err := manager.DetectManager(root)
-	if err != nil {
-		managerName = ""
-	}
-
-	// run manager version if available
-	if managerName != "" {
-		driver, ok := manager.GetManager(managerName)
-		if ok {
-			spec := driver.BuildVersion()
-			if err := manager.Exec(spec, root); err != nil {
-				return err
-			}
-		}
-	}
+func RunVersion() error {
+	fmt.Fprintf(os.Stdout, "miso %s\n", Version)
 	return nil
 }

--- a/apps/miso/internal/cli/completion/completion.go
+++ b/apps/miso/internal/cli/completion/completion.go
@@ -105,17 +105,14 @@ func getCandidates(prev string, cur string, cwd string) []string {
 	return names
 }
 
-// ScriptBash returns the bash completion script.
 func ScriptBash() string {
 	return scripts.Bash
 }
 
-// ScriptZsh returns the zsh completion script.
 func ScriptZsh() string {
 	return scripts.Zsh
 }
 
-// ScriptFish returns the fish completion script.
 func ScriptFish() string {
 	return scripts.Fish
 }

--- a/apps/miso/internal/cli/env/env.go
+++ b/apps/miso/internal/cli/env/env.go
@@ -17,7 +17,6 @@ import (
 
 const EnvFlag = "--env"
 
-// HasEnvFlag returns true if --env is in the given args
 func HasEnvFlag(args []string) bool {
 	for _, a := range args {
 		if a == EnvFlag {
@@ -27,7 +26,6 @@ func HasEnvFlag(args []string) bool {
 	return false
 }
 
-// StripEnvFlag returns a copy of args with --env removed
 func StripEnvFlag(args []string) []string {
 	out := make([]string, 0, len(args))
 	for _, a := range args {
@@ -38,7 +36,6 @@ func StripEnvFlag(args []string) []string {
 	return out
 }
 
-// StripEnvFromFlags returns a copy of cfg with --env removed from all flag slices
 func StripEnvFromFlags(cfg config.Config) config.Config {
 	if cfg.Flags == nil {
 		return cfg

--- a/apps/miso/internal/config/config.go
+++ b/apps/miso/internal/config/config.go
@@ -122,12 +122,12 @@ func (c *Config) EnsureDefaults() {
 	}
 }
 
-// IsMonorepo returns true for repo modes that use workspace discovery.
+// mono, turbo, or nx
 func (c Config) IsMonorepo() bool {
 	return c.Repo == "mono" || c.Repo == "turbo" || c.Repo == "nx"
 }
 
-// RepoMode returns the resolved repo mode string, defaulting to "single".
+// defaults to "single"
 func (c Config) RepoMode() string {
 	if c.Repo == "" {
 		return "single"
@@ -135,13 +135,12 @@ func (c Config) RepoMode() string {
 	return c.Repo
 }
 
-// IsDelegated returns true when orchestration is delegated to turbo or nx.
+// turbo or nx
 func (c Config) IsDelegated() bool {
 	return c.Repo == "turbo" || c.Repo == "nx"
 }
 
-// HasDependsOn returns true if the given command has a dependsOn entry with a ^ prefix
-// in the tasks configuration.
+// checks for ^ prefix in dependsOn
 func (c Config) HasDependsOn(command string) bool {
 	if c.Tasks == nil {
 		return false
@@ -158,7 +157,6 @@ func (c Config) HasDependsOn(command string) bool {
 	return false
 }
 
-// TaskConcurrent returns the concurrent task names for the given command, or nil.
 func (c Config) TaskConcurrent(command string) []string {
 	if c.Tasks == nil {
 		return nil
@@ -173,12 +171,10 @@ func (c Config) TaskConcurrent(command string) []string {
 	return task.Concurrent
 }
 
-// TuiEnabled returns true when the multi-terminal UI is active (tabbed or merged mode)
 func (c Config) TuiEnabled() bool {
 	return c.TuiMode == "tabbed" || c.TuiMode == "merged"
 }
 
-// SimpleMode returns true when package manager features are disabled.
 func (c Config) SimpleMode() bool {
 	return c.PackageManager != nil && !*c.PackageManager
 }
@@ -444,8 +440,7 @@ func Save(root string, cfg Config) error {
 	return nil
 }
 
-// LoadWorkspaces reads workspace glob patterns from the root package.json
-// and expands them into actual directory paths that exist on disk.
+// expands globs; returns only paths that exist on disk
 func LoadWorkspaces(root string) ([]string, error) {
 	pkgPath := filepath.Join(root, "package.json")
 	data, err := os.ReadFile(pkgPath)

--- a/apps/miso/internal/manager/detect.go
+++ b/apps/miso/internal/manager/detect.go
@@ -18,7 +18,6 @@ var lockfileMap = map[string]string{
 
 var ErrNoLockfile = errors.New("no lockfile detected")
 
-// LockfileNames returns the list of lockfile filenames for project root detection.
 func LockfileNames() []string {
 	names := make([]string, 0, len(lockfileMap))
 	for k := range lockfileMap {

--- a/apps/miso/internal/tui/depgraph.go
+++ b/apps/miso/internal/tui/depgraph.go
@@ -13,8 +13,7 @@ type PackageInfo struct {
 	Deps []string // combined dependencies + devDependencies package names
 }
 
-// ReadPackageInfo reads a workspace's package.json and extracts name and dependency names.
-// Returns empty PackageInfo (not an error) if package.json doesn't exist.
+// empty PackageInfo (not error) when package.json doesn't exist
 func ReadPackageInfo(dir string) (PackageInfo, error) {
 	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
 	if err != nil {
@@ -51,9 +50,7 @@ func ReadPackageInfo(dir string) (PackageInfo, error) {
 	return PackageInfo{Name: pkg.Name, Deps: deps}, nil
 }
 
-// BuildDependencyGraph reads package.json from each workspace and builds an adjacency
-// list mapping workspace names to the workspace names they depend on.
-// Only dependencies that match another workspace's package name are included.
+// only intra-workspace dependencies; external packages excluded
 func BuildDependencyGraph(workspaces []WorkspaceInfo) (map[string][]string, error) {
 	type wsInfo struct {
 		ws      WorkspaceInfo

--- a/apps/miso/internal/tui/discover.go
+++ b/apps/miso/internal/tui/discover.go
@@ -15,7 +15,6 @@ type WorkspaceInfo struct {
 	Dir  string
 }
 
-// TuiScriptEntry represents a single script that can be launched from the TUI.
 type TuiScriptEntry struct {
 	Label        string
 	ScriptName   string

--- a/apps/miso/internal/tui/process.go
+++ b/apps/miso/internal/tui/process.go
@@ -11,7 +11,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-// ProcessState represents the lifecycle state of a managed process.
 type ProcessState int
 
 const (
@@ -20,13 +19,11 @@ const (
 	StateExited
 )
 
-// ProcessOutputMsg is a bubbletea message carrying a single captured output line.
 type ProcessOutputMsg struct {
 	Label string
 	Line  string
 }
 
-// ProcessStateMsg is a bubbletea message indicating a process state change.
 type ProcessStateMsg struct {
 	Label string
 	State ProcessState
@@ -57,7 +54,6 @@ type ProcessManager struct {
 	program   *tea.Program
 }
 
-// NewProcessManager creates an empty ProcessManager.
 func NewProcessManager() *ProcessManager {
 	return &ProcessManager{}
 }
@@ -69,7 +65,6 @@ func (pm *ProcessManager) SetProgram(p *tea.Program) {
 	pm.program = p
 }
 
-// Add creates a new Process entry and appends it to the manager.
 func (pm *ProcessManager) Add(entry TuiScriptEntry, command string, args []string, dir string, environ []string) *Process {
 	p := &Process{
 		Entry:   entry,
@@ -273,7 +268,6 @@ func (pm *ProcessManager) sendOutput(p *Process, line string) {
 	}
 }
 
-// AllExited returns true if every process has reached StateExited.
 func (pm *ProcessManager) AllExited() bool {
 	pm.mu.Lock()
 	procs := make([]*Process, len(pm.Processes))
@@ -294,7 +288,6 @@ func (pm *ProcessManager) AllExited() bool {
 	return true
 }
 
-// FailedCount returns the number of processes that exited with non-zero code.
 func (pm *ProcessManager) FailedCount() int {
 	pm.mu.Lock()
 	procs := make([]*Process, len(pm.Processes))

--- a/apps/miso/internal/tui/ringbuf.go
+++ b/apps/miso/internal/tui/ringbuf.go
@@ -32,7 +32,7 @@ func (rb *RingBuffer) Write(line string) {
 	}
 }
 
-// Lines returns all lines in the buffer in order (oldest to newest).
+// oldest to newest
 func (rb *RingBuffer) Lines() []string {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
@@ -60,7 +60,6 @@ func (rb *RingBuffer) Clear() {
 	rb.count = 0
 }
 
-// Len returns the current number of lines in the buffer.
 func (rb *RingBuffer) Len() int {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()

--- a/apps/miso/internal/turbo/config.go
+++ b/apps/miso/internal/turbo/config.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 )
 
-// TurboTask represents a single task definition from turbo.json.
 type TurboTask struct {
 	DependsOn  []string `json:"dependsOn"`
 	Cache      *bool    `json:"cache"`
@@ -25,7 +24,7 @@ type TurboConfig struct {
 	Tasks   map[string]TurboTask
 }
 
-// TaskNames returns the sorted list of task names in the config.
+// sorted
 func (c TurboConfig) TaskNames() []string {
 	names := make([]string, 0, len(c.Tasks))
 	for name := range c.Tasks {
@@ -41,8 +40,6 @@ type rawTurboConfig struct {
 	Pipeline map[string]TurboTask `json:"pipeline"`
 }
 
-// LoadConfig reads turbo.json from root and returns a TurboConfig.
-//
 // Behaviour:
 //   - File not found → empty TurboConfig with initialized Tasks map, nil error.
 //   - Malformed JSON → error.

--- a/apps/miso/internal/turbo/output.go
+++ b/apps/miso/internal/turbo/output.go
@@ -21,9 +21,7 @@ type LineMeta struct {
 	CacheHit *bool
 }
 
-// ParseLine parses a single line of turbo output into a LineMeta.
-// Lines that do not match the turbo workspace output format are returned
-// with Skip set to true.
+// non-matching lines returned with Skip=true
 func ParseLine(line string) LineMeta {
 	matches := turboLineRe.FindStringSubmatch(line)
 	if matches == nil {

--- a/packages/skills/miso-config/SKILL.md
+++ b/packages/skills/miso-config/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: miso-config
+description: Reference for creating and modifying miso.json configuration files
+---
+
 # miso-config
 
 **Use this skill** any time you need to create or modify `miso.json`.

--- a/packages/skills/miso-env/SKILL.md
+++ b/packages/skills/miso-env/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: miso-env
+description: Reference for configuring env validation and understanding miso's .env file loading
+---
+
 # miso-env
 
 **Use this skill** when configuring env validation, debugging env injection, or understanding which `.env` files miso loads.

--- a/packages/skills/miso-scripting/SKILL.md
+++ b/packages/skills/miso-scripting/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: miso-scripting
+description: Reference for creating, organizing, and debugging scripts in a miso scripts/ folder
+---
+
 # miso-scripting
 
 **Use this skill** any time you need to create, organize, name, or debug scripts in a miso `scripts/` folder.

--- a/packages/skills/miso-tui/SKILL.md
+++ b/packages/skills/miso-tui/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: miso-tui
+description: Reference for configuring miso's TUI display modes, task ordering, and concurrent tasks
+---
+
 # miso-tui
 
 **Use this skill** when configuring multi-process TUI display, task ordering, or concurrent tasks.

--- a/scripts/release/build/npm.sh
+++ b/scripts/release/build/npm.sh
@@ -12,16 +12,19 @@ cd "$REPO_ROOT"
 mkdir -p dist/bin
 cd apps/miso
 
-CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o ../../dist/bin/miso-darwin-amd64 ./cmd
-CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o ../../dist/bin/miso-darwin-arm64 ./cmd
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../dist/bin/miso-linux-amd64 ./cmd
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ../../dist/bin/miso-linux-arm64 ./cmd
-CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o ../../dist/bin/miso-windows-amd64.exe ./cmd
-CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o ../../dist/bin/misox-darwin-amd64 ./cmd
-CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o ../../dist/bin/misox-darwin-arm64 ./cmd
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../../dist/bin/misox-linux-amd64 ./cmd
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ../../dist/bin/misox-linux-arm64 ./cmd
-CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o ../../dist/bin/misox-windows-amd64.exe ./cmd
+VERSION=$(node -p "require('./package.json').version")
+LDFLAGS="-X github.com/ekkolyth/miso/internal/cli/commands.Version=$VERSION"
+
+CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/miso-darwin-amd64 ./cmd
+CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/miso-darwin-arm64 ./cmd
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/miso-linux-amd64 ./cmd
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/miso-linux-arm64 ./cmd
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/miso-windows-amd64.exe ./cmd
+CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/misox-darwin-amd64 ./cmd
+CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/misox-darwin-arm64 ./cmd
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/misox-linux-amd64 ./cmd
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/misox-linux-arm64 ./cmd
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o ../../dist/bin/misox-windows-amd64.exe ./cmd
 
 chmod +x \
   ../../dist/bin/miso-darwin-amd64 \


### PR DESCRIPTION
This PR Fixes a couple of bugs from the latest 0.5.0 release. 

- `miso version` - regression with the new installer, and some odd old behavior cleaned up (no need for passthrough on this one as a built-in command)
- `miso skills` - the command worked, but I missed adding frontmatter to the skill definitions. 
- General codebase cleanup after the release

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR fixes two regressions from the 0.5.0 release — `miso version` now correctly reports the binary version via build-time `-ldflags` injection instead of a fragile filesystem walk, and all four skill definitions gain the required YAML frontmatter so `miso skills` can discover them — alongside a broad comment-cleanup pass across the Go codebase.

- **`version.go` / `main.go`**: `GetMisoVersion()` (which walked up from the binary location looking for `package.json`) is replaced by a `var Version = \"unknown\"` package variable stamped at build time. `RunVersion()` loses the now-unnecessary `root`/`cfg` parameters, and the manager passthrough is intentionally dropped.
- **`npm.sh`**: Extracts `VERSION` from `apps/miso/package.json` via `node -p` and passes it to every `go build` call as `-ldflags \"-X …commands.Version=$VERSION\"`, correctly wiring the build-time injection.
- **Skill frontmatter** (`miso-config`, `miso-env`, `miso-scripting`, `miso-tui`): Each `SKILL.md` gains a `name` + `description` YAML block so the skill loader can index them.
- **Comment cleanup**: Doc comments on many exported Go identifiers are removed or shortened to inline fragments. One consequence is that `turbo/config.go`'s `LoadConfig` loses its opening function-name sentence, leaving only the `// Behaviour:` block as the doc comment (see inline comment).

<h3>Confidence Score: 5/5</h3>

Safe to merge — both bug fixes are correct and the only remaining item is a one-line style cleanup in a doc comment.

The version regression fix is sound: the ldflags variable path matches the package structure, the build script correctly reads the version from package.json, and the simplified RunVersion() is cleaner. Skill frontmatter additions are straightforward. The broad comment-cleanup is a style preference with one minor convention gap in turbo/config.go (orphaned Behaviour block), which is non-blocking.

apps/miso/internal/turbo/config.go — LoadConfig doc comment lost its opening function-name sentence.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/miso/internal/cli/commands/version.go | Replaces fragile walk-up-from-binary package.json search with a build-time ldflags variable; clean simplification. |
| scripts/release/build/npm.sh | Adds VERSION extraction from package.json and passes it via -ldflags to all go build invocations; straightforward and correct for semver strings. |
| apps/miso/cmd/main.go | Removes unnecessary config/project-root loading before the version command; now calls the simplified RunVersion() with no arguments. |
| apps/miso/internal/turbo/config.go | Removes leading function-name doc line from LoadConfig, leaving an orphaned // Behaviour: block as the only doc comment; minor convention issue. |
| packages/skills/miso-config/SKILL.md | Adds missing YAML frontmatter (name + description) required for skill discovery. |
| packages/skills/miso-env/SKILL.md | Adds missing YAML frontmatter (name + description) required for skill discovery. |
| packages/skills/miso-scripting/SKILL.md | Adds missing YAML frontmatter (name + description) required for skill discovery. |
| packages/skills/miso-tui/SKILL.md | Adds missing YAML frontmatter (name + description) required for skill discovery. |
| apps/miso/internal/config/config.go | Replaces verbose exported-function doc comments with brief inline comments; no logic changes. |
| apps/miso/internal/tui/process.go | Strips doc comments from exported types and methods; no logic changes. |
| apps/miso/internal/cli/completion/completion.go | Removes doc comments from three exported functions; no logic changes. |
| apps/miso/internal/cli/env/env.go | Removes doc comments from three exported functions; no logic changes. |
| apps/miso/internal/manager/detect.go | Removes doc comment from exported LockfileNames function; no logic change. |
| apps/miso/internal/tui/depgraph.go | Shortens doc comments on ReadPackageInfo and BuildDependencyGraph; no logic changes. |
| apps/miso/internal/tui/discover.go | Removes doc comment from exported TuiScriptEntry type; no logic change. |
| apps/miso/internal/tui/ringbuf.go | Shortens doc comments on Lines and removes comment on Len; no logic changes. |
| apps/miso/internal/turbo/output.go | Shortens doc comment on ParseLine to a single inline line; no logic change. |
| apps/miso/internal/cli/commands/upgrade.go | Minor comment brevity change on HTTPClient interface; no logic change. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/miso/internal/turbo/config.go`, line 43-49 ([link](https://github.com/ekkolyth/miso/blob/4018fbe906957b1c00293bc65255a261007ddd1c/apps/miso/internal/turbo/config.go#L43-L49)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Orphaned behaviour block after removing function name**

   The leading sentence `// LoadConfig reads turbo.json from root and returns a TurboConfig.` was removed, but the `// Behaviour:` block that followed it was kept. The block is still technically the doc comment for `LoadConfig`, but it no longer opens with the conventional `// FuncName does X` sentence, which makes `go doc` output look odd and loses the function-name anchor.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/miso/internal/turbo/config.go
   Line: 43-49

   Comment:
   **Orphaned behaviour block after removing function name**

   The leading sentence `// LoadConfig reads turbo.json from root and returns a TurboConfig.` was removed, but the `// Behaviour:` block that followed it was kept. The block is still technically the doc comment for `LoadConfig`, but it no longer opens with the conventional `// FuncName does X` sentence, which makes `go doc` output look odd and loses the function-name anchor.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/miso/internal/turbo/config.go
Line: 43-49

Comment:
**Orphaned behaviour block after removing function name**

The leading sentence `// LoadConfig reads turbo.json from root and returns a TurboConfig.` was removed, but the `// Behaviour:` block that followed it was kept. The block is still technically the doc comment for `LoadConfig`, but it no longer opens with the conventional `// FuncName does X` sentence, which makes `go doc` output look odd and loses the function-name anchor.

```suggestion
// LoadConfig reads turbo.json from root and returns a TurboConfig.
//
// Behaviour:
//   - File not found → empty TurboConfig with initialized Tasks map, nil error.
//   - Malformed JSON → error.
//   - Neither "tasks" nor "pipeline" key present → error.
//   - "tasks" key present → Version 2.
//   - "pipeline" key present → Version 1.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["comment cleanup"](https://github.com/ekkolyth/miso/commit/4018fbe906957b1c00293bc65255a261007ddd1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27284119)</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->